### PR TITLE
TASK: Prevent writing to unimplemented memory locations

### DIFF
--- a/Processor.cs
+++ b/Processor.cs
@@ -791,6 +791,9 @@ namespace PIC_Simulator
 
         internal void SetFile(ushort address, byte value)
         {
+            // Nicht-implementierte memory locations nicht beschreiben!
+            if (address == 0x07 || address == 0x87) return;
+
             ushort[] addresses = DecodeAddress(address);
 
             foreach (ushort element in addresses)

--- a/Processor.cs
+++ b/Processor.cs
@@ -793,6 +793,8 @@ namespace PIC_Simulator
         {
             // Nicht-implementierte memory locations nicht beschreiben!
             if (address == 0x07 || address == 0x87) return;
+            if (address >= 0x50 && address <= 0x7F) return;
+            if (address >= 0xD0 && address <= 0xFF) return;
 
             ushort[] addresses = DecodeAddress(address);
 


### PR DESCRIPTION
Nichtimplementierte Adressen sollen als '0' gelesen werden. Da sie eben damit initialisiert werden, muss nur der Schreibzugriff geblockt werden.

Closes #4 